### PR TITLE
'default' typo raised a warning in dev tools

### DIFF
--- a/lib/atom-spotify.coffee
+++ b/lib/atom-spotify.coffee
@@ -7,7 +7,7 @@ module.exports =
       default: true
     showEqualizer:
       type: 'boolean'
-      defautl: false
+      default: false
     showPlayStatus:
       type: 'boolean'
       default: true


### PR DESCRIPTION
There's a typo that raised a warning - I think the default is false anyway so that was working.

```
'atom-spotify2.showEqualizer' could not set the default. Attempted default: undefined; Schema: {"type":"boolean","defautl":false}
```
